### PR TITLE
chore: replace GitHub dependabot reviewers with codeowners (INTERN-68)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# GitHub Actions files
+/.github/               @skriptfabrik/github-actions-maintainers


### PR DESCRIPTION
This pull request will replace the retiring dependabot reviewers configuration with CODEOWNERS.