### PR TITLE
Fix/ansible lint action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
         uses: frenck/action-yamllint@v1
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6.17.0
+        uses: ansible/ansible-lint@v26
 
   molecule:
     name: Run Molecule Tests

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,6 +4,13 @@ rules:
   line-length:
     max: 160
     level: warning
-  comments: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 ignore: |
   .github/

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,7 +7,7 @@
       when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
       block:
         - name: Install openssh on CentOS
-          ansible.builtin.yum:
+          ansible.builtin.dnf:
             name:
               - openssh-clients
               - openssh-server
@@ -25,5 +25,5 @@
       ansible.builtin.file:
         path: /var/run/sshd
         state: directory
-        mode: 0755
+        mode: "0755"
         owner: root

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: ansible.windows
+  - name: community.crypto
+  - name: community.general

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -23,7 +23,7 @@
   ansible.builtin.template:
     src: revoked_keys.j2
     dest: "{{ sshd_config_path }}/revoked_keys"
-    mode: 0600
+    mode: "0600"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
 
@@ -32,7 +32,7 @@
   when: sshd_version.stdout >= '8.2'
   ansible.builtin.file:
     path: "{{ sshd_config_path }}/sshd_config.d"
-    mode: 0700
+    mode: "0700"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
 
@@ -43,7 +43,7 @@
   ansible.builtin.template:
     src: opensshd.conf.j2
     dest: "{{ sshd_config_path }}/sshd_config"
-    mode: 0600
+    mode: "0600"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
     validate: /usr/sbin/sshd -T -C user=root -C host=localhost -C addr=localhost -f %s
@@ -53,7 +53,7 @@
   when: sshd_version.stdout >= "8.2"
   ansible.builtin.file:
     path: "{{ sshd_config_path }}/ssh_config.d"
-    mode: 0755
+    mode: "0755"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
 
@@ -63,7 +63,7 @@
   ansible.builtin.template:
     src: openssh.conf.j2
     dest: "{{ sshd_config_path }}/ssh_config"
-    mode: 0644
+    mode: "0644"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
 

--- a/tasks/distribution/Linux.yml
+++ b/tasks/distribution/Linux.yml
@@ -77,7 +77,7 @@
 - name: "Linux : Remove all small primes"
   register: _remove_small_primes
   notify: Restart linux sshd
-  when: sshd_register_moduli.stdout
+  when: sshd_register_moduli.stdout | length > 0
   ansible.builtin.shell:
     cmd: |
       awk '$5 >= {{ sshd_moduli_minimum }}' {{ sshd_moduli_file }} > {{ sshd_moduli_file }}.new ;

--- a/tasks/distribution/subtasks/2fa.yml
+++ b/tasks/distribution/subtasks/2fa.yml
@@ -9,7 +9,7 @@
 - name: Install google authenticator PAM module
   become: true
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: google-authenticator
     state: present
 

--- a/tasks/distribution/subtasks/ca_keys_and_principals.yml
+++ b/tasks/distribution/subtasks/ca_keys_and_principals.yml
@@ -5,7 +5,7 @@
   ansible.builtin.template:
     src: trusted_user_ca_keys.j2
     dest: "{{ ssh_trusted_user_ca_keys_file }}"
-    mode: 0644
+    mode: "0644"
     owner: "{{ ssh_owner }}"
     group: "{{ ssh_group }}"
 

--- a/tasks/distribution/subtasks/host_keys.yml
+++ b/tasks/distribution/subtasks/host_keys.yml
@@ -6,7 +6,7 @@
       ansible.builtin.copy:
         content: "{{ _ssh_host_key_file.private_key }}"
         dest: "{{ _ssh_host_key_file.path }}"
-        mode: 0600
+        mode: "0600"
 
     - name: Get checksum of provided pre defined private ssh host key
       register: __provided_private_host_key
@@ -25,7 +25,7 @@
       ansible.builtin.copy:
         content: "{{ _ssh_host_key_file.public_key }}"
         dest: "{{ _ssh_host_key_file.path }}.pub"
-        mode: 0644
+        mode: "0644"
 
 - name: Validate key type
   ansible.builtin.assert:

--- a/tasks/distribution/subtasks/selinux.yml
+++ b/tasks/distribution/subtasks/selinux.yml
@@ -36,14 +36,14 @@
         state: directory
         owner: root
         group: root
-        mode: 0750
+        mode: "0750"
 
     - name: Distributing custom selinux policies
       become: true
       ansible.builtin.copy:
         src: ssh_password
         dest: '{{ ssh_custom_selinux_dir }}'
-        mode: 0640
+        mode: "0640"
 
     - name: Check and compile policy
       become: true


### PR DESCRIPTION
Replace deprecated `ansible-community/ansible-lint-action@v6.17.0` with the official successor `ansible/ansible-lint@v26`.